### PR TITLE
Allow returnURL to be function

### DIFF
--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -29,6 +29,7 @@ var passport = require('@passport-next/passport-strategy')
  *
  * Options:
  *   - `returnURL`         URL to which the OpenID provider will redirect the user after authentication
+ *                         May be given as a function which will get the req object as an argument.
  *   - `realm`             the part of URL-space for which an OpenID authentication request is valid
  *   - `profile`           enable profile exchange, defaults to _false_
  *   - `pape`              when present, enables the OpenID Provider Authentication Policy Extension
@@ -136,9 +137,9 @@ function Strategy(options, verify) {
     var oauth = new openid.OAuthHybrid(oauthOptions);
     extensions.push(oauth);
   }
-  
-  this._relyingParty = new openid.RelyingParty(
-    options.returnURL,
+
+  this._relyingParty = req => new openid.RelyingParty(
+    options.returnURL instanceof Function ? options.returnURL(req) : options.returnURL,
     options.realm,
     (options.stateless === undefined) ? false : options.stateless,
     (options.secure === undefined) ? true : options.secure,
@@ -180,7 +181,7 @@ Strategy.prototype.authenticate = function(req) {
     if (req.query['openid.mode'] === 'cancel') { return this.fail({ message: 'OpenID authentication canceled' }); }
     
     var self = this;
-    this._relyingParty.verifyAssertion(req.url, function(err, result) {
+    this._relyingParty(req).verifyAssertion(req.url, function(err, result) {
       if (err) { return self.error(new InternalOpenIDError('Failed to verify assertion', err)); }
       if (!result.authenticated) { return self.error(new Error('OpenID authentication failed')); }
       
@@ -245,7 +246,7 @@ Strategy.prototype.authenticate = function(req) {
     if (!identifier) { return this.fail(new BadRequestError('Missing OpenID identifier')); }
 
     var self = this;
-    this._relyingParty.authenticate(identifier, false, function(err, providerUrl) {
+    this._relyingParty(req).authenticate(identifier, false, function(err, providerUrl) {
       if (err || !providerUrl) { return self.error(new InternalOpenIDError('Failed to discover OP endpoint URL', err)); }
       self.redirect(providerUrl);
     });


### PR DESCRIPTION
I've verified this works and is backwards compatible, but the way `_relyingParty` is defined inside the constructor and then mocked in the tests, I don't actually see any simple way to update the tests to handle this simple (internal) change.

See related

- https://github.com/jaredhanson/passport-openid/issues/21
- https://github.com/jaredhanson/passport-openid/issues/38
- https://github.com/jaredhanson/passport-google/issues/17