### PR TITLE
Allow the return URL to vary per connection.

### DIFF
--- a/lib/passport-openid/strategy.js
+++ b/lib/passport-openid/strategy.js
@@ -137,9 +137,9 @@ function Strategy(options, verify) {
     extensions.push(oauth);
   }
   
-  this._relyingParty = new openid.RelyingParty(
-    options.returnURL,
-    options.realm,
+  this._relyingParty = req => new openid.RelyingParty(
+    options.returnURL instanceof Function ? options.returnURL(req) : options.returnURL,
+    options.realm instanceof Function ? options.realm(req) : options.realm,
     (options.stateless === undefined) ? false : options.stateless,
     (options.secure === undefined) ? true : options.secure,
     extensions);
@@ -180,7 +180,7 @@ Strategy.prototype.authenticate = function(req) {
     if (req.query['openid.mode'] === 'cancel') { return this.fail({ message: 'OpenID authentication canceled' }); }
     
     var self = this;
-    this._relyingParty.verifyAssertion(req.url, function(err, result) {
+    this._relyingParty(req).verifyAssertion(req.url, function(err, result) {
       if (err) { return self.error(new InternalOpenIDError('Failed to verify assertion', err)); }
       if (!result.authenticated) { return self.error(new Error('OpenID authentication failed')); }
       
@@ -245,7 +245,7 @@ Strategy.prototype.authenticate = function(req) {
     if (!identifier) { return this.fail(new BadRequestError('Missing OpenID identifier')); }
 
     var self = this;
-    this._relyingParty.authenticate(identifier, false, function(err, providerUrl) {
+    this._relyingParty(req).authenticate(identifier, false, function(err, providerUrl) {
       if (err || !providerUrl) { return self.error(new InternalOpenIDError('Failed to discover OP endpoint URL', err)); }
       self.redirect(providerUrl);
     });


### PR DESCRIPTION
Allows the `returnURL` and `realm` properties to be a string (old behavior) **or** a function (new behavior).

Previously you could only use a string, such as:
`returnURL: 'http://localhost:3000/auth/openid/return'`

With this change, you can also use a function that takes the request as a parameter, such as:
`returnURL: req => 'http://localhost:3000/auth/openid/return' + querystring.stringify(req.query)`

This provides a simple way to preserve some request information through the login process, without the need for sessions/cookies/etc.